### PR TITLE
Add build pipeline properties

### DIFF
--- a/.bluemix/deploy.json
+++ b/.bluemix/deploy.json
@@ -7,7 +7,8 @@
   "properties": {
     "deploy-region": {
       "description": "The bluemix region",
-      "type": "string"
+      "type": "string",
+      "pattern": "^(ibm:yp:us-south|ibm:ys1:us-south)$"
     },
     "deploy-organization": {
       "description": "The bluemix org",
@@ -16,31 +17,26 @@
     "deploy-space": {
       "description": "The bluemix space",
       "type": "string"
+    },
+    "blockchain-service-instance": {
+      "description": "The Blockchain service. This service will be created if it does not already exist.",
+      "type": "string"
+    },
+    "cloudant-service-instance": {
+      "description": "The Cloudant NoSQL DB that will be used to store Business Network Cards. This service will be created if it does not already exist.",
+      "type": "string"
     }
   },
   "required": [
     "deploy-region",
     "deploy-organization",
-    "deploy-space"
+    "deploy-space",
+    "blockchain-service-instance",
+    "cloudant-service-instance"
   ],
   "form": [{
       "type": "validator",
       "url": "/devops/setup/bm-helper/helper.html"
-    },
-    {
-      "type": "table",
-      "columnCount": 1,
-      "widths": [ "100%" ],
-      "items": [
-        {
-          "type": "label",
-          "title": "Cloud Foundry and OpenWhisk"
-        },
-        {
-          "type": "label",
-          "title": "The toolchain will deploy the Fibonacci service as a Cloud Foundry application with a random route and as an OpenWhisk action. The action will also be exposed as an HTTP endpoint. Specify the space where the application and the action will be deployed."
-        }
-      ]
     },
     {
       "type": "table",
@@ -49,23 +45,25 @@
       "items": [
         {
           "type": "label",
-          "title": "Region (only US South is supported)"
+          "title": "**Region:** (only US South is supported)"
         },
         {
           "type": "label",
-          "title": "Organization"
+          "title": "**Organization:**"
         },
         {
           "type": "label",
-          "title": "Space"
+          "title": "**Space:**"
         },
         {
           "type": "select",
-          "key": "deploy-region"
+          "key": "deploy-region",
+          "readonly": true
         },
         {
           "type": "select",
-          "key": "deploy-organization"
+          "key": "deploy-organization",
+          "readonly": false
         },
         {
           "type": "select",
@@ -73,6 +71,18 @@
           "readonly": false
         }
       ]
+    },
+    {
+      "type": "text",
+      "title": "Blockchain service name",
+      "key": "blockchain-service-instance",
+      "readonly": false
+    },
+    {
+      "type": "text",
+      "title": "Cloudant NoSQL DB service name",
+      "key": "cloudant-service-instance",
+      "readonly": false
     }
   ]
 }

--- a/.bluemix/pipeline-BLOCKCHAIN.sh
+++ b/.bluemix/pipeline-BLOCKCHAIN.sh
@@ -6,7 +6,6 @@ source .bluemix/pipeline-COMMON.sh
 
 export BLOCKCHAIN_SERVICE_NAME=ibm-blockchain-5-prod
 export BLOCKCHAIN_SERVICE_PLAN=ibm-blockchain-plan-v1-starter-prod
-export BLOCKCHAIN_SERVICE_INSTANCE=${BLOCKCHAIN_EXISTING_SERVICE_INSTANCE:-blockchain-${IDS_PROJECT_NAME}}
 export BLOCKCHAIN_SERVICE_KEY=Credentials-1
 export BLOCKCHAIN_NETWORK_CARD=admin@blockchain-network
 

--- a/.bluemix/pipeline-CLOUDANT.sh
+++ b/.bluemix/pipeline-CLOUDANT.sh
@@ -6,7 +6,6 @@ source .bluemix/pipeline-COMMON.sh
 
 export CLOUDANT_SERVICE_NAME=cloudantNoSQLDB
 export CLOUDANT_SERVICE_PLAN=Lite
-export CLOUDANT_SERVICE_INSTANCE=cloudant-${IDS_PROJECT_NAME}
 export CLOUDANT_SERVICE_KEY=Credentials-1
 export CLOUDANT_DATABASE=wallet
 

--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -7,10 +7,6 @@ stages:
     service: ${REPO}
   triggers:
   - type: commit
-  properties:
-  - name: BLOCKCHAIN_EXISTING_SERVICE_INSTANCE
-    value: '{{sin}}'
-    type: text
   jobs:
   - name: Build
     type: builder
@@ -25,8 +21,11 @@ stages:
   triggers:
   - type: stage
   properties:
-  - name: BLOCKCHAIN_EXISTING_SERVICE_INSTANCE
-    value: '{{sin}}'
+  - name: BLOCKCHAIN_SERVICE_INSTANCE
+    value: ${BLOCKCHAIN_SERVICE_INSTANCE}
+    type: text
+  - name: CLOUDANT_SERVICE_INSTANCE
+    value: ${CLOUDANT_SERVICE_INSTANCE}
     type: text
   jobs:
   - name: Deploy

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -3,9 +3,8 @@ template:
   name: "Blockchain Starter Kit"
   description: "Deploy the IBM Blockchain Starter Kit to IBM Cloud."
   required:
-    - build
     - repo
-    - deploy
+    - build
 
 toolchain:
   name: 'blockchain-starter-kit-{{timestamp}}'
@@ -14,7 +13,7 @@ services:
   repo:
     service_id: githubpublic
     parameters:
-      repo_name: 'blockchain-starter-kit-{{timestamp}}'
+      repo_name: '{{toolchain.name}}'
       repo_url: 'https://github.com/sstone1/blockchain-starter-kit'
       type: clone
       has_issues: true
@@ -35,11 +34,17 @@ services:
           SPACE_NAME: '{{form.pipeline.parameters.deploy-space}}'
           ORG_NAME: '{{form.pipeline.parameters.deploy-organization}}'
           REGION_ID: '{{form.pipeline.parameters.deploy-region}}'
+          BLOCKCHAIN_SERVICE_INSTANCE: '{{form.pipeline.parameters.blockchain-service-instance}}'
+          CLOUDANT_SERVICE_INSTANCE: '{{form.pipeline.parameters.cloudant-service-instance}}'
         execute: true
 
 form:
   pipeline:
-    # parameters:
-      # deploy-region: 'ibm:yp:us-south'
     schema:
       $ref: deploy.json
+    parameters:
+      deploy-region: '{{region}}'
+      deploy-organization: '{{organization}}'
+      deploy-space: '{{space}}'
+      blockchain-service-instance: '{{sin}}'
+      cloudant-service-instance: '{{toolchain.name}}'

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ You must now specify a name for your clone of this GitHub repository. We recomme
 
 ![Toolchain GitHub options specified](./media/toolchain-github-specified.png)
 
+Finally, you must specify a name for the Blockchain service instance you will be using on the Delivery Pipeline form. This can either be an existing service name, or the name of a new Blockchain service to create. Similary for a Cloudant NoSQL DB service which will be used as storage for a Composer wallet. For this example, I'll use "simons-blockchain-service" as the name of the new Blockchain service and "simons-cloudant-service" as the name of the new Cloudant NoSQL DB service.
+
 That's it! Click the "Create" button to create your new DevOps toolchain, and GitHub repository. You should be taken to your newly created DevOps toolchain page:
 
 ![Toolchain created](./media/toolchain-created.png)


### PR DESCRIPTION
Include blockchain and cloudant service names to properties
required for build pipeline

This allows multiple starter kit toolchains to target the same
blockchain and cloud wallet storage if required

Also includes validation for region restriction

Signed-off-by: James Taylor <jamest@uk.ibm.com>