### PR TITLE
Pipeline.yml deploy phase should have the same properties as build phase

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -24,6 +24,10 @@ stages:
     job: Build
   triggers:
   - type: stage
+  properties:
+  - name: BLOCKCHAIN_EXISTING_SERVICE_INSTANCE
+    value: '{{sin}}'
+    type: text
   jobs:
   - name: Deploy
     type: deployer


### PR DESCRIPTION
This prevents production deployments from re-using existing services, and also stops anything on the staging environment from deploying correctly (as it tries to create a production service)

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>